### PR TITLE
Fix Typo in Documentation - "均衡工鞥呢" to "均衡功能"

### DIFF
--- a/learning/k8s-intermediate/service/network.md
+++ b/learning/k8s-intermediate/service/network.md
@@ -200,7 +200,7 @@ Kubernetes 利用 Linux 内建的网络框架 - `netfilter` 来实现负载均�
 
 Kubernetes v1.11 开始，提供了另一个选择用来实现集群内部的负载均衡：[IPVS](/learning/k8s-intermediate/service/service-details.html#ipvs-代理模式)。 IPVS（IP Virtual Server）也是基于 netfilter 构建的，在 Linux 内核中实现了传输层的负载均衡。IPVS 被合并到 LVS（Linux Virtual Server）当中，充当一组服务器的负载均衡器。IPVS 可以转发 TCP / UDP 请求到实际的服务器上，使得一组实际的服务器看起来像是只通过一个单一 IP 地址访问的服务一样。IPVS 的这个特点天然适合与用在 Kubernetes Service 的这个场景下。
 
-当声明一个 Kubernetes Service 时，你可以指定是使用 iptables 还是 IPVS 来提供集群内的负载均衡工鞥呢。IPVS 是转为负载均衡设计的，并且使用更加有效率的数据结构（hash tables），相较于 iptables，可以支持更大数量的网络规模。当创建使用 IPVS 形式的 Service 时，Kubernetes 执行了如下三个操作：
+当声明一个 Kubernetes Service 时，你可以指定是使用 iptables 还是 IPVS 来提供集群内的负载均衡功能。IPVS 是转为负载均衡设计的，并且使用更加有效率的数据结构（hash tables），相较于 iptables，可以支持更大数量的网络规模。当创建使用 IPVS 形式的 Service 时，Kubernetes 执行了如下三个操作：
 * 在节点上创建一个 dummy IPVS interface
 * 将 Service 的 IP 地址绑定到该 dummy IPVS interface
 * 为每一个 Service IP 地址创建 IPVS 服务器


### PR DESCRIPTION
In [specific file path, e.g., docs/usage.md], I noticed a typo in the phrase “负载均衡工鞥呢” (load balancing gong neng ne). The correct term should be “负载均衡功能” (load balancing function). This change improves the readability and professionalism of the documentation.

Impact:
This change is limited to the documentation text and does not affect any code functionality.